### PR TITLE
fix(listAll): only consider markdown files as pages

### DIFF
--- a/autocompletion/autocomplete.bash
+++ b/autocompletion/autocomplete.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function _tldr_autocomplete {
-  pages=$(tldr -a)
+  pages=$(tldr --list-all)
   COMPREPLY=()
   if [ "$COMP_CWORD" = 1 ]; then
     COMPREPLY=($(compgen -W "$pages" -- $2))

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -89,7 +89,7 @@ func (r *Repository) Pages() ([]string, error) {
 
 	pages := []os.FileInfo{}
 	err := filepath.Walk(dir, func(path string, f os.FileInfo, err error) error {
-		if !f.IsDir() {
+		if !f.IsDir() && strings.HasSuffix(f.Name(), ".md") {
 			pages = append(pages, f)
 		}
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please describe in short what you did and if it's not obvious why you did it.

If you get no answer for some days feel free to ping me :)
-->

What I did: I only consider markdown files as pages, so I check if they have a `.md` suffix.

Why I did it: because there came an `index.json` file as a possible outcome for autocompletion and also in the `--list-all` view. 

closes #42
