### PR TITLE
feat(cache): use XDG defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,4 +62,4 @@ test: $(SOURCES)
 
 .PHONY: clean
 clean:
-	rm -Rf bin && rm -Rf ~/.tldr
+	rm -Rf bin; rm -Rf $(XDG_CACHE_HOME)/tldr; rm -Rf ~/.cache/tldr

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Otherwise you can build the executable yourself and copy it wherever you want. O
 |`make test` | runs tests|
 |`make build-all-binaries` | builds all binaries for currently supported platforms|
 |`make compress-all-binaries` | runs build-all-binaries and compresses them|
-|`make clean` | cleans `./bin/` and `~/.tldr/` folders|
+|`make clean` | cleans `./bin/` and cache folders|
 
 ## Autocompletion
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -218,6 +218,13 @@ func (r *Repository) unzip() error {
 }
 
 func cacheDir() (string, error) {
+	XDG_CACHE_HOME := os.Getenv("XDG_CACHE_HOME")
+
+	// Use the XDG_CACHE_HOME environment variable if possible
+	if XDG_CACHE_HOME != "" {
+		return path.Join(XDG_CACHE_HOME, "tldr"), nil
+	}
+
 	usr, err := user.Current()
 	if err != nil {
 		return "", fmt.Errorf("ERROR: getting current user: %s", err)
@@ -229,5 +236,7 @@ func cacheDir() (string, error) {
 		return "", fmt.Errorf("ERROR: loading current user's home directory: %s", err)
 	}
 
-	return path.Join(homeDir, ".tldr"), nil
+	XDG_CACHE_HOME_DEFAULT := ".cache/"
+
+	return path.Join(homeDir, XDG_CACHE_HOME_DEFAULT, "tldr"), nil
 }

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -17,11 +17,20 @@ func contains(arr []string, str string) bool {
 }
 
 func TestCacheDir(t *testing.T) {
-	cacheDir, err := cacheDir()
+	cacheDirectory, err := cacheDir()
 
-	if err != nil || !strings.HasSuffix(cacheDir, ".tldr") {
-		t.Error("Expected linux, got ", err, cacheDir)
+	if err != nil || !strings.HasSuffix(cacheDirectory, ".cache/tldr") {
+		t.Error("Expected to end with `.cache/tldr` but got", err, cacheDirectory)
 	}
+
+	os.Setenv("XDG_CACHE_HOME", "/tmp")
+	cacheDirectory, err = cacheDir()
+
+	if err != nil || (cacheDirectory != "/tmp/tldr") {
+		t.Error("Expected to be `/tmp/.cache/tldr` but got", err, cacheDirectory)
+	}
+
+	os.Setenv("XDG_CACHE_HOME", "")
 }
 
 func TestNewRepository(t *testing.T) {


### PR DESCRIPTION


<!--
Thanks for your contribution!
Please describe in short what you did and if it's not obvious why you did it.

If you get no answer for some days feel free to ping me :)
-->

What I did: I used the `XDG_CACHE_HOME` environment variable if set

Why I did it: because there is a standard which says where to store cache files and not to simply litter the home folder (see #43)

closes #43