### PR TITLE
Only check remote is reachable when ttl timeout.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin
 coverage.txt
 profile.out
+.idea

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -53,10 +53,14 @@ func NewRepository(remote string, ttl time.Duration) (*Repository, error) {
 		if err != nil {
 			return nil, fmt.Errorf("ERROR: loading data from remote: %s", err)
 		}
-	} else if repo.isReachable() && (err != nil || info.ModTime().Before(time.Now().Add(-ttl))) {
-		err = repo.Reload()
-		if err != nil {
-			return nil, fmt.Errorf("ERROR: reloading cache: %s", err)
+	} else if err != nil || info.ModTime().Before(time.Now().Add(-ttl)) {
+		if repo.isReachable() {
+			err = repo.Reload()
+			if err != nil {
+				return nil, fmt.Errorf("ERROR: reloading cache: %s", err)
+			}
+		} else {
+			fmt.Errorf("INFO: remote is not reachable, reload skipped")
 		}
 	}
 


### PR DESCRIPTION
What I did: only call repo.isReachable() when it is actually needed.

Why I did it: Calling repo.isReachable() each time give me a few seconds delay in my environment (WSL2/Ubuntu). Didn't check other environment. 

Because the code path is executed for every invocation of the command line, it gives me a unbearable delay for using it.
