### PR TITLE
Don't try to delete /tldr if XDG_CACHE_HOME is not set.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,4 +62,4 @@ test: $(SOURCES)
 
 .PHONY: clean
 clean:
-	rm -Rf bin; rm -Rf $(XDG_CACHE_HOME)/tldr; rm -Rf ~/.cache/tldr
+	rm -Rf bin; test -z "$(XDG_CACHE_HOME)" || rm -Rf $(XDG_CACHE_HOME)/tldr; rm -Rf ~/.cache/tldr


### PR DESCRIPTION
## What I did:

Test whether `XDG_CACHE_HOME` is empty before using it as a path prefix.

## Why I did it:

Now it no longer tries to delete `/tldr` if this variable is not set (or set to an empty value).

Fixes #51.
