### PR TITLE
Add Android platform; Import testify; Fix tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 ### Misc
 
+## [1.3.1] - 2021-06-21
+
+-   Add support for `Android` pages. [#53](https://github.com/mstruebing/tldr/pull/58) ([@conves](https://github.com/conves))
+
 ## [1.3.0] - 2020-10-05
 
 -   Add `history` function for the past page view. [#53](https://github.com/mstruebing/tldr/pull/53) ([@wudong](https://github.com/wudong))

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -5,16 +5,9 @@ import (
 	"strings"
 	"testing"
 	"time"
-)
 
-func contains(arr []string, str string) bool {
-	for _, a := range arr {
-		if a == str {
-			return true
-		}
-	}
-	return false
-}
+	"github.com/stretchr/testify/require"
+)
 
 func TestCacheDir(t *testing.T) {
 	cacheDirectory, err := cacheDir()
@@ -58,35 +51,23 @@ func TestNewRepository(t *testing.T) {
 	}
 }
 
-func TestPlattforms(t *testing.T) {
+func TestPlatforms(t *testing.T) {
 	remote := "https://tldr.sh/assets/tldr.zip"
 	ttl := time.Hour * 24 * 7
-	r, _ := NewRepository(remote, ttl)
+	r, err := NewRepository(remote, ttl)
+	require.NoError(t, err, "NewRepository() error %v", err)
 
-	platforms, _ := r.AvailablePlatforms()
-	if len(platforms) != 5 {
-		t.Error("Expected 5 Platforms, got", len(platforms))
-	}
+	platforms, err := r.AvailablePlatforms()
+	require.NoError(t, err, "AvailablePlatforms() error %v", err)
 
-	if !contains(platforms, "linux") {
-		t.Error("Expected linux in platforms, got", platforms)
-	}
+	require.Len(t, platforms, 6, "expected 5 platforms, got", len(platforms))
 
-	if !contains(platforms, "common") {
-		t.Error("Expected common in platforms, got", platforms)
-	}
-
-	if !contains(platforms, "osx") {
-		t.Error("Expected osx in platforms, got", platforms)
-	}
-
-	if !contains(platforms, "sunos") {
-		t.Error("Expected sunos in platforms, got", platforms)
-	}
-
-	if !contains(platforms, "windows") {
-		t.Error("Expected windows in platforms, got", platforms)
-	}
+	require.Contains(t, platforms, "android", "expected android in platforms, got", platforms)
+	require.Contains(t, platforms, "linux", "expected linux in platforms, got", platforms)
+	require.Contains(t, platforms, "common", "expected common in platforms, got", platforms)
+	require.Contains(t, platforms, "osx", "expected osx in platforms, got", platforms)
+	require.Contains(t, platforms, "sunos", "expected sunos in platforms, got", platforms)
+	require.Contains(t, platforms, "windows", "expected windows in platforms, got", platforms)
 }
 
 func TestReload(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/mstruebing/tldr
 
 go 1.12
+
+require github.com/stretchr/testify v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/unidoc/unioffice v1.5.0 h1:RxPbPMBgKJ7gbqVlq/gZ+zd0gWWfvDUhm2ODbyMdfZk=
 github.com/unidoc/unioffice v1.5.0/go.mod h1:7wl8btOkZW1TfqfpDWoujRXkUpowwisGRYDo7COHBiI=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please describe in short what you did and if it's not obvious why you did it.

If you get no answer for some days feel free to ping me :)
-->

What I did:
1. I added Android to the list of available platforms, as it was breaking tests.
2. I imported [testify](https://github.com/stretchr/testify). (MIT)
3. I also refactored the `TestAvailablePlatforms` function to table driven tests.

Why I did it:
1. I think this is the recent [PR to tldr-pages](https://github.com/tldr-pages/tldr/pull/5743) that added Android and started breaking tests.
2. I'm using `testify` extensively in other projects, and it just makes my life way easier. :)
3. Table driven is the idiomatic way of writing tests in Go.
