### PR TITLE
test: use cat instead of non existing hostname in linux for testing

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -87,13 +87,13 @@ func TestMarkdown(t *testing.T) {
 	ttl := time.Hour * 24 * 7
 	r, _ := NewRepository(remote, ttl)
 
-	_, err := r.Markdown("linux", "hostname")
+	_, err := r.Markdown("linux", "cat")
 
 	if err != nil {
 		t.Error("Expected to successfully pull a page from the cache")
 	}
 
-	_, err = r.Markdown("linux", "hostnamee")
+	_, err = r.Markdown("linux", "catt")
 
 	if err == nil {
 		t.Error("Expected to return an error for non existing pages")

--- a/render_test.go
+++ b/render_test.go
@@ -1,6 +1,7 @@
 package tldr
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -9,7 +10,8 @@ import (
 
 func TestRender(t *testing.T) {
 	r, _ := cache.NewRepository(remoteURL, ttl)
-	markdown, _ := r.Markdown("linux", "hostname")
+	markdown, _ := r.Markdown("linux", "cat")
+	fmt.Println("markdown:", markdown)
 
 	render, err := Render(markdown)
 
@@ -24,7 +26,7 @@ func TestRender(t *testing.T) {
 
 func TestWrite(t *testing.T) {
 	r, _ := cache.NewRepository(remoteURL, ttl)
-	markdown, _ := r.Markdown("linux", "hostname")
+	markdown, _ := r.Markdown("linux", "cat")
 
 	err := Write(markdown, os.Stdout)
 


### PR DESCRIPTION
The `hostname` utilty got removed from linux for whatever reason so we are using `cat` now.
I dont think this will change as often so I dont think this needs to be more generic for now.
